### PR TITLE
Fix length strategies cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ In this section we have collected some further information for developers.
 - Keycloak: [https://localhost/auth/](https://localhost/auth/) (Admin user: `dev:dev`)
 - PGAdmin: [https://localhost:5433/](https://localhost:5433/) (Password: `dev`)
 
+### CLI
+To run the CLI version first put the videos for masking into the folder `data/backend/videos`. Then execute the following commands:
+```
+docker compose -f docker-compose-cli.yml build
+docker compose -f docker-compose-cli.yml run cli python3 cli.py --input-path /data/videos --output-path /data/results --hiding-strategy blurring --overlay-strategy mp_pose # example
+```
+Possible hiding strategies are: `solid_fill, transparent_fill, blurring, pixelation, contours, none`.
+
+Possible overlay strategies are: `mp_hand, mp_face, mp_pose, openpose, openpose_body25b, openpose_face, openpose_body_135, none`.
+
+The results will be stored in `/data/backend/results`. Note that you have to clear the results folder before masking again, otherwise it will not mask any video.
+
 ### Debugging
 Run the application with 
 ```bash

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,0 +1,57 @@
+
+services:
+  cli:
+    build:
+      context: ./docker/worker
+    command: "python cli.py"
+    env_file:
+      - ./app.env
+    volumes:
+      - ./worker:/app
+      - ./data/backend:/data
+    depends_on:
+      - sam2
+      - openpose
+    restart: on-failure
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ['0']
+                capabilities: [ gpu ]
+
+  sam2:
+    build:
+      context: ./docker/sam2
+    command: "uvicorn main:app --reload --proxy-headers --host 0.0.0.0 --root-path /api/"
+    env_file:
+      - ./app.env
+    volumes:
+      - ./sam2:/app
+    restart: on-failure
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ['0']
+                capabilities: [ gpu ]
+
+  openpose:
+    build:
+      context: ./docker/openpose
+    command: "uvicorn main:app --reload --proxy-headers --host 0.0.0.0 --root-path /api/"
+    env_file:
+      - ./app.env
+    volumes:
+      - ./openpose:/app
+      - ./docker/openpose/models:/models
+    restart: on-failure
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ['0']
+                capabilities: [ gpu ]

--- a/worker/cli.py
+++ b/worker/cli.py
@@ -141,6 +141,9 @@ def process_video(input_file, output_file, sam2_client, openpose_client, hiding_
     }
 
     # Duplicate strategies based on the number of pose prompt entries
+    if len(first_frame_pose_prompts) == 0:
+        raise ValueError(f"No high confidence valid poses found. Ensure the video contains a person and is not empty.")
+    
     max_size = len(first_frame_pose_prompts)
     hiding_strategies = duplicate_strategies(hiding_strategy, max_size)
     overlay_strategies = duplicate_strategies(overlay_strategy, max_size)

--- a/worker/cli.py
+++ b/worker/cli.py
@@ -141,7 +141,7 @@ def process_video(input_file, output_file, sam2_client, openpose_client, hiding_
     }
 
     # Duplicate strategies based on the number of pose prompt entries
-    max_size = max(len(p) for p in pose_prompts[str(frame_number)])  # Get the max length of pose prompt entries
+    max_size = len(first_frame_pose_prompts)
     hiding_strategies = duplicate_strategies(hiding_strategy, max_size)
     overlay_strategies = duplicate_strategies(overlay_strategy, max_size)
 


### PR DESCRIPTION
Set the `max_length` to the number of detected persons. Previously it was set to the maximum number of pose points (e.g. 2) used in the first frame, which resulted in an error, if having more persons (e.g. 8) than there are pose points (2).

Also added a docker compose for the CLI.