### PR TITLE
Set GPU ID via environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 DOCKER_REGISTRY=ghcr.io/maskanyone/maskanyone/
 DOCKER_TAG=latest
+MASKANYONE_GPU_ID=0

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -18,7 +18,7 @@ services:
           reservations:
             devices:
               - driver: nvidia
-                device_ids: ['0']
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
                 capabilities: [ gpu ]
 
   sam2:
@@ -35,7 +35,7 @@ services:
           reservations:
             devices:
               - driver: nvidia
-                device_ids: ['0']
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
                 capabilities: [ gpu ]
 
   openpose:
@@ -53,5 +53,5 @@ services:
           reservations:
             devices:
               - driver: nvidia
-                device_ids: ['0']
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
                 capabilities: [ gpu ]

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -13,13 +13,6 @@ services:
       - sam2
       - openpose
     restart: on-failure
-    deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
 
   sam2:
     build:
@@ -31,12 +24,17 @@ services:
       - ./sam2:/app
     restart: on-failure
     deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${MASKANYONE_GPU_ID:-0}"]
+              capabilities: [ gpu ]
+    # devices: # use in case the new resource reservation with GPU IDs is not working, uses GPU 0 by default
+    #   - /dev/nvidia0:/dev/nvidia0
+    #   - /dev/nvidiactl:/dev/nvidiactl
+    #   - /dev/nvidia-uvm:/dev/nvidia-uvm
+    #   - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
 
   openpose:
     build:
@@ -49,9 +47,14 @@ services:
       - ./docker/openpose/models:/models
     restart: on-failure
     deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${MASKANYONE_GPU_ID:-0}"]
+              capabilities: [ gpu ]
+    # devices: # use in case the new resource reservation with GPU IDs is not working, uses GPU 0 by default
+    #   - /dev/nvidia0:/dev/nvidia0
+    #   - /dev/nvidiactl:/dev/nvidiactl
+    #   - /dev/nvidia-uvm:/dev/nvidia-uvm
+    #   - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,13 +73,6 @@ services:
     depends_on:
       - python
     restart: on-failure
-    deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
 
   sam2:
     build:
@@ -91,12 +84,17 @@ services:
       - ./sam2:/app
     restart: on-failure
     deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${MASKANYONE_GPU_ID:-0}"]
+              capabilities: [ gpu ]
+    # devices: # use in case the new resource reservation with GPU IDs is not working, uses GPU 0 by default
+    #   - /dev/nvidia0:/dev/nvidia0
+    #   - /dev/nvidiactl:/dev/nvidiactl
+    #   - /dev/nvidia-uvm:/dev/nvidia-uvm
+    #   - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
 
   openpose:
     build:
@@ -109,9 +107,14 @@ services:
       - ./docker/openpose/models:/models
     restart: on-failure
     deploy:
-        resources:
-          reservations:
-            devices:
-              - driver: nvidia
-                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
-                capabilities: [ gpu ]
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${MASKANYONE_GPU_ID:-0}"]
+              capabilities: [ gpu ]
+    # devices: # use in case the new resource reservation with GPU IDs is not working, uses GPU 0 by default
+    #   - /dev/nvidia0:/dev/nvidia0
+    #   - /dev/nvidiactl:/dev/nvidiactl
+    #   - /dev/nvidia-uvm:/dev/nvidia-uvm
+    #   - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,13 +73,13 @@ services:
     depends_on:
       - python
     restart: on-failure
-#    deploy:
-#      resources:
-#        reservations:
-#          devices:
-#            - driver: nvidia
-#              count: 1
-#              capabilities: [gpu]
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
+                capabilities: [ gpu ]
 
   sam2:
     build:
@@ -91,20 +91,12 @@ services:
       - ./sam2:/app
     restart: on-failure
     deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [ gpu ]
-    runtime: nvidia
-    environment:
-      - NVIDIA_DISABLE_REQUIRE=1
-    devices:
-      - /dev/nvidia0:/dev/nvidia0
-      - /dev/nvidiactl:/dev/nvidiactl
-      - /dev/nvidia-uvm:/dev/nvidia-uvm
-      - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
+                capabilities: [ gpu ]
 
   openpose:
     build:
@@ -117,17 +109,9 @@ services:
       - ./docker/openpose/models:/models
     restart: on-failure
     deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [ gpu ]
-    runtime: nvidia
-    environment:
-      - NVIDIA_DISABLE_REQUIRE=1
-    devices:
-      - /dev/nvidia0:/dev/nvidia0
-      - /dev/nvidiactl:/dev/nvidiactl
-      - /dev/nvidia-uvm:/dev/nvidia-uvm
-      - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ["{MASKANYONE_GPU_ID:-0}"]
+                capabilities: [ gpu ]


### PR DESCRIPTION
@martin-schilling It would be good, if you could try to run this to see, if this also works on your computer with the GPU. It would be good for us to have this functionality, because sometimes GPU 0 is occupied by other students from other seminars. Merging #60 is necessary beforehand.